### PR TITLE
Add `terminate_if_die` option to freeway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+A fork of [MinAtar](https://github.com/kenjyoung/MinAtar). These points are changed from the original MinAtar:
+
+- In Freeway, new option `terminal_if_die` is added. If true, the episode ends when the agent is hit by a car.
+
+
+---
+
+
 # MinAtar
 MinAtar is a testbed for AI agents which implements miniaturized versions of several Atari 2600 games. MinAtar is inspired by the Arcade Learning Environment (Bellemare et. al. 2013) but simplifies the games to make experimentation with the environments more accessible and efficient. Currently, MinAtar provides analogues to five Atari games which play out on a 10x10 grid. The environments provide a 10x10xn state representation, where each of the n channels correspond to a game-specific object, such as ball, paddle and brick in the game Breakout.
 

--- a/minatar/environments/freeway.py
+++ b/minatar/environments/freeway.py
@@ -44,6 +44,7 @@ class Env:
         else:
             self.random = random_state
         self.reset()
+        self.terminate_if_die = False
 
     # Update environment according to agent action
     def act(self, a):
@@ -70,6 +71,8 @@ class Env:
         for car in self.cars:
             if(car[0:2]==[4,self.pos]):
                 self.pos = 9
+                if self.terminate_if_die:
+                    self.terminal = True
             if(car[2]==0):
                 car[2]=abs(car[3])
                 car[0]+=1 if car[3]>0 else -1
@@ -79,6 +82,8 @@ class Env:
                     car[0]=0
                 if(car[0:2]==[4,self.pos]):
                     self.pos = 9
+                    if self.terminate_if_die:
+                        self.terminal = True
             else:
                 car[2]-=1
 


### PR DESCRIPTION
Validated by following script.

```py
from minatar import Environment

env = Environment(env_name="freeway")
env.env.terminate_if_die = True
env.reset()
terminal = False
while not terminal:
    _, terminal = env.act(2)
    env.display_state(10)
```