### PR TITLE
Move last action from `Environment` class to each game class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-A fork of [MinAtar](https://github.com/kenjyoung/MinAtar). These points are changed from the original MinAtar:
+A fork of [MinAtar](https://github.com/kenjyoung/MinAtar) for personal use. These points are changed from the original MinAtar:
 
-- In Freeway, new option `terminate_if_die` is added. If true, the episode ends when the agent is hit by a car. [#1](https://github.com/sotetsuk/MinAtar/pull/1)
+- In Freeway, new option `terminate_if_die` is added. If true, the episode ends immediately when the agent is hit by a car. [#1](https://github.com/sotetsuk/MinAtar/pull/1)
 - Store random state for reproducing the same state transactions. [#2](https://github.com/sotetsuk/MinAtar/pull/2)
-- Save gif animation [#3](https://github.com/sotetsuk/MinAtar/pull/3)
+- Move `last_action` attribute from `Environment` class to each game class. [#5](https://github.com/sotetsuk/MinAtar/pull/5)
+- Save gif animation. [#3](https://github.com/sotetsuk/MinAtar/pull/3)
 
 ---
 

--- a/minatar/environment.py
+++ b/minatar/environment.py
@@ -17,9 +17,8 @@ import numpy as np
 class Environment:
     def __init__(self, env_name, sticky_action_prob = 0.1, difficulty_ramping = True, random_seed = None):
         env_module = import_module('minatar.environments.'+env_name)
-        self.random = np.random.RandomState(random_seed)
         self.env_name = env_name
-        self.env = env_module.Env(ramping = difficulty_ramping, random_state = self.random)
+        self.env = env_module.Env(ramping = difficulty_ramping, random_state = np.random.RandomState(random_seed))
         self.n_channels = self.env.state_shape()[2]
         self.sticky_action_prob = sticky_action_prob
         self.last_action = 0
@@ -30,7 +29,7 @@ class Environment:
 
     # Wrapper for env.act
     def act(self, a):
-        if(self.random.rand()<self.sticky_action_prob):
+        if(self.env.random.rand() < self.sticky_action_prob):
             a = self.last_action
         self.last_action = a
         return self.env.act(a)

--- a/minatar/environment.py
+++ b/minatar/environment.py
@@ -21,7 +21,6 @@ class Environment:
         self.env = env_module.Env(ramping = difficulty_ramping, random_state = np.random.RandomState(random_seed))
         self.n_channels = self.env.state_shape()[2]
         self.sticky_action_prob = sticky_action_prob
-        self.last_action = 0
         self.visualized = False
         self.closed = False
         self.ims = []
@@ -30,8 +29,8 @@ class Environment:
     # Wrapper for env.act
     def act(self, a):
         if(self.env.random.rand() < self.sticky_action_prob):
-            a = self.last_action
-        self.last_action = a
+            a = self.env.last_action
+        self.env.last_action = a
         return self.env.act(a)
 
     # Wrapper for env.state

--- a/minatar/environments/asterix.py
+++ b/minatar/environments/asterix.py
@@ -152,6 +152,7 @@ class Env:
         self.ramp_index = 0
         self.terminal = False
         self.random_state = self.random.get_state()
+        self.last_action = 0
 
     # Dimensionality of the game-state (10x10xn)
     def state_shape(self):

--- a/minatar/environments/breakout.py
+++ b/minatar/environments/breakout.py
@@ -127,6 +127,7 @@ class Env:
         self.last_y = self.ball_y
         self.terminal = False
         self.random_state = self.random.get_state()
+        self.last_action = 0
 
     # Dimensionality of the game-state (10x10xn)
     def state_shape(self):

--- a/minatar/environments/freeway.py
+++ b/minatar/environments/freeway.py
@@ -146,6 +146,7 @@ class Env:
         self.terminate_timer = time_limit
         self.terminal = False
         self.random_state = self.random.get_state()
+        self.last_action = 0
 
     # Dimensionality of the game-state (10x10xn)
     def state_shape(self):

--- a/minatar/environments/seaquest.py
+++ b/minatar/environments/seaquest.py
@@ -310,6 +310,7 @@ class Env:
         self.surface = True
         self.terminal = False
         self.random_state = self.random.get_state()
+        self.last_action = 0
 
     # Dimensionality of the game-state (10x10xn)
     def state_shape(self):

--- a/minatar/environments/space_invaders.py
+++ b/minatar/environments/space_invaders.py
@@ -153,6 +153,7 @@ class Env:
         self.shot_timer = 0
         self.terminal = False
         self.random_state = self.random.get_state()
+        self.last_action = 0
 
     # Dimensionality of the game-state (10x10xn)
     def state_shape(self):


### PR DESCRIPTION
Due to the sticky action, the state transition depends on the last action.
For #2, I moved `last_action` attribute from `Environment` class to each game class to treat it as the internal state.